### PR TITLE
Add deployment trigger note for v0.0.1 (GitHub Pages)

### DIFF
--- a/DEPLOYMENT-NOTE.md
+++ b/DEPLOYMENT-NOTE.md
@@ -1,0 +1,1 @@
+# Deployment Trigger Note\n\nThis file is added to create a commit for the PR that triggers the GitHub Pages deployment workflow.\n\n- Version: 0.0.1\n- Purpose: Trigger build and deploy on merge to main.\n\nNo functional changes to the application.


### PR DESCRIPTION
Added DEPLOYMENT-NOTE.md to trigger the GitHub Pages deployment workflow upon merge. This is a minor update (v0.0.1) with no functional changes to the application. Assumes billing issue resolved.