### PR TITLE
Remove deprecated @types/react-joyride dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
         "@tanstack/react-query": "^5.83.0",
-        "@types/react-joyride": "^2.0.5",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -4396,15 +4395,6 @@
       "devOptional": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
-      }
-    },
-    "node_modules/@types/react-joyride": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@types/react-joyride/-/react-joyride-2.0.5.tgz",
-      "integrity": "sha512-N3bd0w3D42gZRpXy/wYsSZ8JvhyuyN0qAFTkg2iNsJ1NueMqfI0TJL+BZhhFkAqNhEETJEpDc8t4bj3DEJyLoQ==",
-      "deprecated": "This is a stub types definition. react-joyride provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "react-joyride": "*"
       }
     },
     "node_modules/@types/resolve": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tanstack/react-query": "^5.83.0",
-    "@types/react-joyride": "^2.0.5",
+
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",


### PR DESCRIPTION
## Changes

- Removed `@types/react-joyride` from `package.json` as it is deprecated and unnecessary.
- Updated `package-lock.json` via `npm install`.

## Summary

- **Why**: The `@types/react-joyride` package is deprecated since `react-joyride` v2.9.3 includes its own TypeScript definitions, reducing bundle size and maintenance overhead.
- **Impact**: Minimal; the project builds successfully (`npm run build`) and TypeScript compiles without errors (`tsc --noEmit`). No direct imports of the deprecated types were found in the codebase.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/63bef3c8-0dd7-402f-85bc-a4418515e354/task/6e47baa4-9e38-4477-ab7c-c73bf7246440))